### PR TITLE
Created resolver file

### DIFF
--- a/server/schemas/index.js
+++ b/server/schemas/index.js
@@ -1,0 +1,4 @@
+const typeDefs = require('./typeDefs');
+const resolvers = require('./resolvers');
+
+module.exports = { typeDefs, resolvers };

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -1,0 +1,70 @@
+const { User } = require('../models');
+const { signToken, AuthenticationError } = require('../utils/auth');
+
+const resolvers = {
+    Query: {
+        me: async (parent, args, context) => {
+            if (context.user) {
+                return User.findOne({ _id: context.user._id });
+            }
+            throw AuthenticationError;
+        },
+    },
+
+    Mutation: {
+        addUser: async (parent, { username, email, password }) => {
+            const user = await User.create({ username, email, password });
+            const token = signToken(user);
+            return { token, user };
+        },
+
+        login: async (parent, { email, password }) => {
+            const user = await User.findOne({ email });
+
+            if (!user) {
+                throw AuthenticationError;
+            }
+
+            const correctPw = await user.isCorrectPassword(password);
+
+            if (!correctPw) {
+                throw AuthenticationError;
+            }
+
+            const token = signToken(user);
+
+            return { token, user };
+        },
+
+        saveBook: async (parent, { bookData }, context) => {
+            console.log(bookData);
+            console.log(context);
+            try {
+                const updatedUser = await User.findOneAndUpdate(
+                    { _id: context.user._id},
+                    { $addToSet: { savedBooks: bookData } },
+                    { new: true, runValidators: true }
+                );
+                return updatedUser;
+            } catch (err) {
+                console.log(err);
+                throw AuthenticationError;
+            }
+        },
+
+        removeBook: async (parent, bookId, context) => {
+            console.log(bookId);
+            const updatedUser = await User.findOneAndUpdate(
+                { _id: context.user._id },
+                { $pull: { savedBooks: { bookId: bookId } } },
+                { new: true }
+            );
+            if (!updatedUser) {
+                throw AuthenticationError;
+            }
+            return updatedUser;
+        },
+    },
+};
+
+module.exports = resolvers;


### PR DESCRIPTION
Created index file to export typeDefs and resolvers

Implemented GraphQL resolvers for user authentication, user creation, login, saving books, and removing books. Resolvers handle queries and mutations, including context-based operations for authenticated users. Added error handling using AuthenticationError from the authentication utility. The 'saveBook' resolver utilizes $addToSet to prevent duplicate saved books, and 'removeBook' uses $pull to remove a book by its ID.